### PR TITLE
Indent blank lines inside JSX and parenthesized expressions.

### DIFF
--- a/tsi-json.el
+++ b/tsi-json.el
@@ -65,7 +65,7 @@
   "Internal function.
 
   Calculate indentation for the current line."
-  (tsi-walk #'tsi-json--get-indent-for))
+  (tsi-indent-line #'tsi-json--get-indent-for))
 
 (defun tsi-json--outdent-line ()
   "Outdents by `tsi-json-indent-offset`."

--- a/tsi-typescript.el
+++ b/tsi-typescript.el
@@ -314,13 +314,28 @@
      (or parent-indentation 0)
      (or child-indentation 0))))
 
+
+(defun tsi--current-line-empty-p ()
+  (string-match-p "\\`[[:space:]]*$" (thing-at-point 'line)))
+
+(defun tsi-typescript--get-indent-for-current-line ()
+  (let* ((node-at-point (tree-sitter-node-at-point))
+         (current-type (tsc-node-type node-at-point)))
+    (cond
+     ((and
+       (or (eq current-type 'jsx_opening_element)
+           (eq current-type 'jsx_self_closing_element)
+           (eq current-type 'parenthesized_expression))
+       (tsi--current-line-empty-p)) 2)
+     (t 0))))
+
 ;; exposed for testing purposes
 ;;;###autoload
 (defun tsi-typescript--indent-line ()
   "Internal function.
 
   Calculate indentation for the current line."
-  (tsi-walk #'tsi-typescript--get-indent-for))
+  (tsi-indent-line #'tsi-typescript--get-indent-for #'tsi-typescript--get-indent-for-current-line))
 
 (defun tsi-typescript--outdent-line ()
   "Outdents by `tsi-typescript-indent-offset`."

--- a/tsi-typescript.el
+++ b/tsi-typescript.el
@@ -326,7 +326,7 @@
        (or (eq current-type 'jsx_opening_element)
            (eq current-type 'jsx_self_closing_element)
            (eq current-type 'parenthesized_expression))
-       (tsi--current-line-empty-p)) 2)
+       (tsi--current-line-empty-p)) tsi-typescript-indent-offset)
      (t 0))))
 
 ;; exposed for testing purposes

--- a/tsi-typescript.test.el
+++ b/tsi-typescript.test.el
@@ -333,6 +333,35 @@ function() {
   
 }
 "
+      :to-be-indented))
+
+ (it "properly indents whitepace in multi-line JSX opening elements"
+     (expect
+      "
+<div
+  
+>
+</div>
+"
+      :to-be-indented))
+
+  (it "properly indents whitepace in multi-line JSX self-closing elements"
+     (expect
+      "
+<div
+  
+/>
+"
+      :to-be-indented))
+
+(it "properly indents whitespace in multi-line parenthesis"
+     (expect
+      "
+if (
+  
+) {
+}
+"
       :to-be-indented)))
 
 (buttercup-run-discover)


### PR DESCRIPTION
Fixes #8.

Indent blank lines in JSX expression line this, where represents the  `|` the cursor after tabbing from the beginning of the line:

```tsx
<div>
  |  
</div>
```

Do the same with self closing JSX elements:

```tsx
<div
  |  
/>
```

And with parenthesized expressions:

```ts
if (
  x === 3
) {
}
```
