### PR TITLE
Fix some issues indenting blank lines with switch statements and arrow expressions.

### DIFF
--- a/tsi-typescript.el
+++ b/tsi-typescript.el
@@ -56,7 +56,10 @@
               'enum_body)
              (eq
               current-type
-              'import_clause))
+              'import_clause)
+             (eq
+              current-type
+              'switch_body))
             (if (and
                  (> (line-number-at-pos) (car (tsc-node-start-point current-node)))
                  (< (line-number-at-pos) (car (tsc-node-end-point current-node))))
@@ -272,7 +275,7 @@
            ((eq
              parent-type
              'switch_case)
-            (if (tsc-node-named-p current-node)
+            (if (and (tsc-node-named-p current-node) (not (eq current-type 'statement_block)))
                 tsi-typescript-indent-offset
               nil))
 
@@ -378,9 +381,10 @@
         (eq current-type 'jsx_self_closing_element)
         (eq current-type 'type_parameters)
         (eq current-type 'type_arguments)
-        (eq current-type 'switch_body)
         (eq current-type 'switch_case)
         (eq current-type 'switch_default)
+        (and (eq current-type 'switch_body)
+             (not (eq parent-type 'switch_statement)))
         (and (eq current-type 'parenthesized_expression)
              (eq parent-type 'if_statement))
         (and

--- a/tsi-typescript.el
+++ b/tsi-typescript.el
@@ -296,7 +296,7 @@
            ((eq
              parent-type
              'type_annotation)
-            (if (tsc-node-named-p current-node)
+            (if (and (tsc-node-named-p current-node) (not (eq current-type 'object_type)))
                 tsi-typescript-indent-offset
               nil))
 

--- a/tsi-typescript.el
+++ b/tsi-typescript.el
@@ -47,9 +47,6 @@
            ((or
              (eq
               current-type
-              'statement_block)
-             (eq
-              current-type
               'object_type)
              (eq
               current-type
@@ -383,6 +380,7 @@
         (eq current-type 'type_arguments)
         (eq current-type 'switch_case)
         (eq current-type 'switch_default)
+        (eq current-type 'statement_block)
         (and (eq current-type 'switch_body)
              (not (eq parent-type 'switch_statement)))
         (and (eq current-type 'parenthesized_expression)

--- a/tsi-typescript.el
+++ b/tsi-typescript.el
@@ -376,9 +376,13 @@
        (or
         (eq current-type 'jsx_opening_element)
         (eq current-type 'jsx_self_closing_element)
-        (eq current-type 'parenthesized_expression)
         (eq current-type 'type_parameters)
         (eq current-type 'type_arguments)
+        (eq current-type 'switch_body)
+        (eq current-type 'switch_case)
+        (eq current-type 'switch_default)
+        (and (eq current-type 'parenthesized_expression)
+             (eq parent-type 'if_statement))
         (and
          (eq current-type 'object)
          (or (eq parent-type 'return_statement)

--- a/tsi-typescript.test.el
+++ b/tsi-typescript.test.el
@@ -511,7 +511,7 @@ type C = A &
 "
       :to-be-indented))
 
- (it "property indents type aliases"
+ (it "properly indents type aliases"
      (expect
       "
 type X = {
@@ -520,7 +520,7 @@ type X = {
 "
       :to-be-indented))
 
- (it "property indents switch statement bodies"
+ (it "properly indents switch statement bodies"
      (expect
       "
 switch (x) {
@@ -528,7 +528,7 @@ switch (x) {
 }
 "
       :to-be-indented))
- (it "property indents case statements"
+ (it "properly indents case statements"
      (expect
       "
 switch (x) {
@@ -539,7 +539,7 @@ switch (x) {
 "
       :to-be-indented))
 
- (it "property indents default statements"
+ (it "properly indents default statements"
      (expect
       "
 switch (condition) {

--- a/tsi-typescript.test.el
+++ b/tsi-typescript.test.el
@@ -373,7 +373,7 @@ function() {
   
 }
 "
-    :to-be-indented))
+      :to-be-indented))
 
  (it "properly indents whitepace in multi-line JSX opening elements"
      (expect
@@ -413,6 +413,17 @@ if (
 }
 "
       :to-be-indented))
+
+ (it "properly indents whitespace in arrow functions with parenthesis"
+     (expect
+      "
+const X = () => (
+  3
+  
+);
+"
+      :to-be-indented))
+
 
  (it "properly indents multi-line objects in return statements"
      (expect
@@ -487,6 +498,39 @@ type X = {
   
 }
 "
-      :to-be-indented)))
+      :to-be-indented))
+
+ (it "property indents switch statement bodies"
+     (expect
+      "
+switch (x) {
+  
+}
+"
+      :to-be-indented))
+ (it "property indents case statements"
+     (expect
+      "
+switch (x) {
+  case 1:
+    
+    3;
+}
+"
+      :to-be-indented))
+
+ (it "property indents default statements"
+     (expect
+      "
+switch (condition) {
+  case expression:
+    break;
+  default:
+    
+    return 4;
+}
+"
+      :to-be-indented)
+))
 
 (buttercup-run-discover)

--- a/tsi-typescript.test.el
+++ b/tsi-typescript.test.el
@@ -97,7 +97,18 @@ type Foo = Omit<
   'baz'
 >;
 "
-      :to-be-indented)))
+      :to-be-indented))
+
+ (it "properly indents object types inside type annotations"
+     (expect
+      "
+interface X {
+  x: {
+    
+  };
+}"
+      :to-be-indented)) 
+ )
 
 (describe
  "indenting union types"

--- a/tsi-typescript.test.el
+++ b/tsi-typescript.test.el
@@ -553,4 +553,55 @@ switch (condition) {
       :to-be-indented)
 ))
 
+(describe
+ "indents new scopes"
+ (it "properly indents expression statement inside statement block "
+     (expect
+      "
+{
+  0
+}
+"
+      :to-be-indented))
+
+ (it "properly indents two expression statements inside statement block "
+     (expect
+      "
+{
+  0
+  0
+}
+"
+      :to-be-indented))
+
+ (it "properly indents expression statement inside statement block with a preceding node"
+     (expect
+      "
+0
+{
+  0
+}
+"
+      :to-be-indented))
+
+ (it "properly indents expression statement inside if block "
+     (expect
+      "
+if (0)
+{
+  0
+}
+"
+      :to-be-indented))
+
+ (it "properly indents expression statement inside statement block preceded by expression statement"
+     (expect
+      "
+0 {
+  0
+}
+"
+      :to-be-indented))
+)
+
 (buttercup-run-discover)

--- a/tsi-typescript.test.el
+++ b/tsi-typescript.test.el
@@ -167,6 +167,15 @@ switch (foo) {
     bar();
 }
 "
+      :to-be-indented))
+
+(it "properly indents blank lines in switch case statements"
+     (expect
+      "
+switch (x) {
+  
+}
+"
       :to-be-indented)))
 
 (describe


### PR DESCRIPTION
Fix some issues indenting blank lines with switch statements and arrow expressions.

## Blank line in a multi-line arrow expressions not getting indented

### Before:

```ts
const X = () => (
  3
| 
^ cursor  is here
);
```

### After

```ts
const X = () => (
  3
  | 
  ^ cursor  is here
);
```

## Initial blank line in switch statement body not getting indented

### Before

```ts
switch (x) {
|
^ cursor is here 
}
```

### After

```ts
switch (x) {
  |
  ^ cursor is here 
}
```

## Blank lines in case statements not indented:

### Before

```ts
switch (x) {
  case 1:
  |
  ^ cursor is here    
    3;
}
```

### After

```ts
switch (x) {
  case 1:
    |
    ^ cursor is here    
    3;
}
```

## Blank lines in switch default statements not indented

### Before

```ts
switch (condition) {
  case expression:
    break;
  default:
  |    
  ^ cursor is here
    return 4;
}
```

### After

```ts
switch (condition) {
  case expression:
    break;
  default:
    |    
    ^ cursor is here
    return 4;
}
```

## Blank lines immediately after switch statements double indented

### Before

```ts
switch (x) {
      |
      cursor is here
}
```

### After

```ts
switch (x) {
    |
    cursor is here
}
```

## Fix indenting of expression statements inside of statement blocks

See c99a38c09d2c49a70a68303ddfd4cdb0d7db419e. Fixes #20. All examples below assume `tsi-typescript-indent-offset` is set to `2`.

### Before

```ts
{
    0
}
```

### After

```ts
{
  0
}
```

### Before

```ts
{
    0
    0
}
```

### After

```ts
{
  0
  0
}
```

### Before

```ts
0
{
    0
}
```

### After

```ts
0
{
  0
}
```

### Before

```ts
if (0)
{
    0
}
```

### After

```ts
if(0)
{
  0
}
```

## Indent Object Types Inside of Type Declarations

See 5a5e463a3ec5b773200c0c040a078dd0baade76d. Example below assumes `tsi-typescript-indent-offset` is set to `2`.

### Before

```ts
interface X {
  x: {
      |
      ^ cursor is here   
  };
}
```

### After

```ts
interface X {
  x: {
    |
    ^ cursor is here   
  };
}
```

