### PR TITLE
Fix indentation of default branches in switch statements.

### DIFF
--- a/tsi-typescript.el
+++ b/tsi-typescript.el
@@ -278,6 +278,13 @@
 
            ((eq
              parent-type
+             'switch_default)
+            (if (tsc-node-named-p current-node)
+                tsi-typescript-indent-offset
+              nil))
+
+           ((eq
+             parent-type
              'type_alias_declaration)
             (if (and (tsc-node-named-p current-node) (not (eq current-type 'object_type)))
                 tsi-typescript-indent-offset

--- a/tsi-typescript.test.el
+++ b/tsi-typescript.test.el
@@ -157,6 +157,16 @@ switch (foo) {
     bar();
 }
 "
+      :to-be-indented))
+
+(it "properly indents default statements"
+     (expect
+      "
+switch (foo) {
+  default:
+    bar();
+}
+"
       :to-be-indented)))
 
 (describe


### PR DESCRIPTION
Fix the indentation of `default` statements.

*Before:*

```ts
switch (foo) {
  default:
  bar();
}
```

Note that `bar()` is not indented.

*After:*

```ts
switch (foo) {
  default:
    bar();
}
```

`bar()` is indented now.