### PR TITLE
Fix indentation of parenthesized types.

### DIFF
--- a/tsi-typescript.el
+++ b/tsi-typescript.el
@@ -252,6 +252,13 @@
             (if (tsc-node-named-p current-node)
                 tsi-typescript-indent-offset
               nil))
+           
+           ((eq
+             parent-type
+             'parenthesized_type)
+            (if (tsc-node-named-p current-node)
+                tsi-typescript-indent-offset
+              nil))
 
            ((eq
              parent-type

--- a/tsi-typescript.test.el
+++ b/tsi-typescript.test.el
@@ -604,4 +604,16 @@ if (0)
       :to-be-indented))
 )
 
+(describe
+ "indenting parenthesis"
+
+ (it "properly indents parenthesized types"
+     (expect
+      "
+let a: (
+  0
+)
+"
+      :to-be-indented)))
+ 
 (buttercup-run-discover)


### PR DESCRIPTION
Fixes #25.

## Before

```ts
let a: (
0
)
```

## After

```ts
let a: (
  0
)
```