### PR TITLE
Fix Blank lines double-indented after {{ and [{,  Indentation of empty lines within [], (), and {} inconsistent

### DIFF
--- a/tsi-typescript.el
+++ b/tsi-typescript.el
@@ -405,10 +405,16 @@ where the current line is empty."
                (eq current-type 'type_arguments)
                (eq current-type 'switch_case)
                (eq current-type 'switch_default)
+               
                (and (eq current-type 'switch_body)
                     (not (eq parent-type 'switch_statement)))
+               
                (and (eq current-type 'parenthesized_expression)
                     (not (eq parent-type 'arrow_function)))
+
+               (and (eq current-type 'arrow_function)
+                    (eq parent-type 'arguments))
+               
                (and
                 (eq current-type 'object)
                 (or (eq parent-type 'return_statement)
@@ -416,6 +422,7 @@ where the current line is empty."
 
                (and (memq current-type tsi-typescript--doubly-nestable-types)
                     (not (or (eq parent-type 'variable_declarator)
+                             (eq parent-type 'arguments)
                              (and (memq parent-type tsi-typescript--doubly-nestable-types) current-parent-same-line-p))))))
              (progn (tsi--debug "indent for current line: %s" tsi-typescript-indent-offset) tsi-typescript-indent-offset))
             (t 0)))))

--- a/tsi-typescript.el
+++ b/tsi-typescript.el
@@ -370,42 +370,62 @@
      (or comment-indentation 0))))
 
 (defun tsi--current-line-empty-p ()
+  "Internal function.
+
+Returns true if the line at point is empty or nothing but whitespace."
   (string-match-p "\\`[[:space:]]*$" (thing-at-point 'line)))
 
+(defun tsi--node-line-num (node)
+  "Internal function.
+
+Return the line number of the start point of the given node."
+  (car (tsc-node-start-point node)))
+
+(defconst tsi-typescript--doubly-nestable-types '(array object statement_block)
+  "List of node  types that can be doubly nested on the same like.
+Used to avoid double indenting blank lines following things like '[{'")
+
 (defun tsi-typescript--get-indent-for-current-line ()
-  (when-let* ((node-at-point (tree-sitter-node-at-point))
+  "Internal function.
+
+Get the indentation to add for the current line. Handles cases
+where the current line is empty."
+  (when-let* ((node-at-point (tree-sitter-node-at-pos))
               (current-type (tsc-node-type node-at-point))
               (parent (tsc-get-parent node-at-point))
               (parent-type (tsc-node-type parent)))
-    (cond
-     ((and
-       (tsi--current-line-empty-p)
-       (or
-        (eq current-type 'jsx_opening_element)
-        (eq current-type 'jsx_self_closing_element)
-        (eq current-type 'type_parameters)
-        (eq current-type 'type_arguments)
-        (eq current-type 'switch_case)
-        (eq current-type 'switch_default)
-        (eq current-type 'statement_block)
-        (and (eq current-type 'switch_body)
-             (not (eq parent-type 'switch_statement)))
-        (and (eq current-type 'parenthesized_expression)
-             (eq parent-type 'if_statement))
-        (and
-         (eq current-type 'object)
-         (or (eq parent-type 'return_statement)
-             (eq parent-type 'array)
-             (eq parent-type 'assignment_expression)))))
-      (progn (tsi--debug "indent for current line: %s" tsi-typescript-indent-offset) tsi-typescript-indent-offset))
-     (t 0))))
+    (let ((current-parent-same-line-p (eq (tsi--node-line-num node-at-point)
+                                          (tsi--node-line-num parent))))
+      (cond ((and
+              (tsi--current-line-empty-p)
+              (or
+               (eq current-type 'jsx_opening_element)
+               (eq current-type 'jsx_self_closing_element)
+               (eq current-type 'type_parameters)
+               (eq current-type 'type_arguments)
+               (eq current-type 'switch_case)
+               (eq current-type 'switch_default)
+               (and (eq current-type 'switch_body)
+                    (not (eq parent-type 'switch_statement)))
+               (and (eq current-type 'parenthesized_expression)
+                    (not (eq parent-type 'arrow_function)))
+               (and
+                (eq current-type 'object)
+                (or (eq parent-type 'return_statement)
+                    (eq parent-type 'assignment_expression)))
+
+               (and (memq current-type tsi-typescript--doubly-nestable-types)
+                    (not (or (eq parent-type 'variable_declarator)
+                             (and (memq parent-type tsi-typescript--doubly-nestable-types) current-parent-same-line-p))))))
+             (progn (tsi--debug "indent for current line: %s" tsi-typescript-indent-offset) tsi-typescript-indent-offset))
+            (t 0)))))
 
 ;; exposed for testing purposes
 ;;;###autoload
 (defun tsi-typescript--indent-line ()
   "Internal function.
 
-  Calculate indentation for the current line."
+   Indent the current line."
   (tsi-indent-line #'tsi-typescript--get-indent-for #'tsi-typescript--get-indent-for-current-line))
 
 (defun tsi-typescript--outdent-line ()
@@ -452,4 +472,5 @@
 
 (provide 'tsi-typescript)
 ;;; tsi-typescript.el ends here
+
 

--- a/tsi-typescript.test.el
+++ b/tsi-typescript.test.el
@@ -424,12 +424,18 @@ function() {
 "
       :to-be-indented))
 
- (it "properly indents whitespace in multi-line parenthesis"
+ (it "properly indents whitespace in if statements multi-line parenthesis"
      (expect
       "
 if (
   
 ) {
+  
+}
+else if (
+  
+) {
+  
 }
 "
       :to-be-indented))
@@ -550,8 +556,33 @@ switch (condition) {
     return 4;
 }
 "
-      :to-be-indented)
-))
+      :to-be-indented))
+
+ (it "properly indents blank lines inside multiline arrays"
+     (expect
+      "
+[
+  
+]
+"
+      :to-be-indented))
+
+ (it "properly blank lines inside nested multiline arrays with delimeters on same line"
+     (expect
+      "
+[[
+  
+]]
+"
+      :to-be-indented))
+
+ (it "properly blank lines inside object in an array with delimeters on same line"
+     (expect
+      "
+[{
+  
+}]"
+      :to-be-indented)))
 
 (describe
  "indents new scopes"

--- a/tsi-typescript.test.el
+++ b/tsi-typescript.test.el
@@ -265,6 +265,15 @@ const foo = (
   b
 ) => a + b;
 "
+      :to-be-indented))
+
+ (it "properly indents object arguments to functions on blank lines"
+     (expect
+      "
+foo({
+  
+});
+"
       :to-be-indented)))
 
 (describe

--- a/tsi-typescript.test.el
+++ b/tsi-typescript.test.el
@@ -582,6 +582,22 @@ switch (condition) {
 [{
   
 }]"
+      :to-be-indented))
+
+ (it "properly blank lines inside an array inside of an object inside of an array"
+     (expect
+      "
+[{[
+  
+]}]"
+      :to-be-indented))
+
+ (it "properly blank lines inside an array inside of an object inside of an object"
+     (expect
+      "
+[{{
+  
+}}]"
       :to-be-indented)))
 
 (describe


### PR DESCRIPTION
Fix #23, partial fix for #30.

With the the delimiters on the same line we were getting indentation like this, with an indent size of 2:

```
[[
    |
    ^ cursor is doubly indentated
]]
```

With this fix we now correctly see this:

```
[[
  |
  ^ cursor is not doubly indentated
]]
```

For the parenthesis cases like this:

```
(

)
```

...the issue seems to be with the [tree-sitter-typescript](https://github.com/tree-sitter/tree-sitter-typescript) grammar. It returns an `ERROR` node. See details [here](https://github.com/orzechowskid/tsi.el/issues/23#issuecomment-1123975198). So this MR does _not_ fix this case.



