### PR TITLE
Properly indent blank lines inside object literals.

### DIFF
--- a/tsi-typescript.el
+++ b/tsi-typescript.el
@@ -423,6 +423,7 @@ where the current line is empty."
                (and (memq current-type tsi-typescript--doubly-nestable-types)
                     (not (or (eq parent-type 'variable_declarator)
                              (eq parent-type 'arguments)
+                             (eq parent-type 'pair)
                              (and (memq parent-type tsi-typescript--doubly-nestable-types) current-parent-same-line-p))))))
              (progn (tsi--debug "indent for current line: %s" tsi-typescript-indent-offset) tsi-typescript-indent-offset))
             (t 0)))))

--- a/tsi-typescript.test.el
+++ b/tsi-typescript.test.el
@@ -526,6 +526,17 @@ type C = A &
 "
       :to-be-indented))
 
+(it "properly indents blank lines inside object literals"
+     (expect
+      "
+{
+  x: {
+    
+  }
+}
+"
+      :to-be-indented))
+
  (it "properly indents type aliases"
      (expect
       "


### PR DESCRIPTION
## Description

Properly indent blank lines inside object literals when the object literal is the value side of an object key / value pair.

Examples below assume `tsi-typescript-indent-offset` is set to `2`:

## Before Behavior

```
{
  x: {
  |
  ^ cursor is here    
  }
}
```

## After Behavior

```
{
  x: {
    |
    ^ cursor is here    
  }
}
```

