### PR TITLE
Properly indent multiline key interpolations

### DIFF
--- a/tsi-typescript.el
+++ b/tsi-typescript.el
@@ -351,6 +351,13 @@
              'binary_expression)
             tsi-typescript-indent-offset)
 
+           ((eq
+             parent-type
+             'computed_property_name)
+            (if (tsc-node-named-p current-node)
+                tsi-typescript-indent-offset
+              nil))
+
            (t nil)))
          (comment-indentation
           (if (and

--- a/tsi-typescript.test.el
+++ b/tsi-typescript.test.el
@@ -700,7 +700,28 @@ let a: (
       "
 0 +
   + 0
-  + 0
+  + 0"
+
+      :to-be-indented)))
+
+(describe 
+ "indenting interpolated keys"
+
+ (it "properly indents multiline interpolated variable declarations"
+     (expect
+      "
+let a: {[
+  0
+]: 0}
+"
+      :to-be-indented))
+
+ (it "properly indents multiline interpolated variable assignments"
+     (expect
+      "
+let a = {[
+  0
+]: 0}
 "
       :to-be-indented)))
  


### PR DESCRIPTION
## Description

Fix #27 - properly indent multiline key interpolations

Examples below assume `tsi-typescript-indent-offset` is set to `2`:

## Before Behavior

```
let a: {[
0
]: 0}
```

```
let a = {[
0
]: 0}
```

## After Behavior

```
let a: {[
  0
]: 0}
```

```
let a = {[
  0
]: 0}
```

