### PR TITLE
Fix multiline operator indentation

### DIFF
--- a/tsi-typescript.el
+++ b/tsi-typescript.el
@@ -345,6 +345,11 @@
             (if (tsc-node-named-p current-node)
                 tsi-typescript-indent-offset
               nil))
+           
+           ((eq
+             parent-type
+             'binary_expression)
+            tsi-typescript-indent-offset)
 
            (t nil)))
          (comment-indentation

--- a/tsi-typescript.test.el
+++ b/tsi-typescript.test.el
@@ -671,5 +671,26 @@ let a: (
 )
 "
       :to-be-indented)))
+
+(describe
+ "multiline operators"
+
+ (it "properly indents Operators split over multiple lines with operators at end of lines"
+     (expect
+      "
+0 +
+  0 +
+  0
+"
+      :to-be-indented))
+ 
+ (it "properly indents Operators split over multiple lines with operators at beginning of lines"
+     (expect
+      "
+0 +
+  + 0
+  + 0
+"
+      :to-be-indented)))
  
 (buttercup-run-discover)


### PR DESCRIPTION
## Description

Fixes #24 - indent operators split over multiple lines properly.

Examples below assume `tsi-typescript-indent-offset` is set to `2`:

## Before Behavior

```
0 +
0 +
0
```

```
0 +
+ 0
+ 0
```

## After Behavior

```
0 +
  0 +
  0
```

```
0 +
  + 0
  + 0
```