### PR TITLE
Fix  Typescript indention of blank lines inside arrays, parens

### DIFF
--- a/tsi-typescript.el
+++ b/tsi-typescript.el
@@ -417,7 +417,8 @@ where the current line is empty."
                (eq current-type 'type_arguments)
                (eq current-type 'switch_case)
                (eq current-type 'switch_default)
-               
+               (eq current-type 'arguments)
+
                (and (eq current-type 'switch_body)
                     (not (eq parent-type 'switch_statement)))
                
@@ -427,15 +428,11 @@ where the current line is empty."
                (and (eq current-type 'arrow_function)
                     (eq parent-type 'arguments))
                
-               (and
-                (eq current-type 'object)
-                (or (eq parent-type 'return_statement)
-                    (eq parent-type 'assignment_expression)))
-
                (and (memq current-type tsi-typescript--doubly-nestable-types)
                     (not (or (eq parent-type 'variable_declarator)
                              (eq parent-type 'arguments)
                              (eq parent-type 'pair)
+                             (eq parent-type 'parenthesized_expression)
                              (and (memq parent-type tsi-typescript--doubly-nestable-types) current-parent-same-line-p))))))
              (progn (tsi--debug "indent for current line: %s" tsi-typescript-indent-offset) tsi-typescript-indent-offset))
             (t 0)))))

--- a/tsi-typescript.test.el
+++ b/tsi-typescript.test.el
@@ -526,7 +526,7 @@ type C = A &
 "
       :to-be-indented))
 
-(it "properly indents blank lines inside object literals"
+ (it "properly indents blank lines inside object literals"
      (expect
       "
 {
@@ -618,6 +618,22 @@ switch (condition) {
 [{{
   
 }}]"
+      :to-be-indented))
+ 
+ (it "properly indents blank lines inside function arguments"
+     (expect
+      "
+f(
+  
+)"
+      :to-be-indented))
+ 
+ (it "properly indents blank lines inside arrays inside parenthesized_expression"
+     (expect
+      "
+if ([
+  
+]) {}"
       :to-be-indented)))
 
 (describe


### PR DESCRIPTION
Fix two issues with indenting blank lines. The examples below assume `tsi-typescript-indent-offset` is set to `2`:

## Properly indents blank lines inside function arguments


### Before

```
f(
|
^ cursor  
)
```

### After

```
f(
  |
  ^ cursor  
)
```

## Properly indents blank lines inside arrays inside parenthesized_expression

### Before

```
if ([
    |
    ^ cursor is here 
) {}
```

### After

```
if ([
  |
  ^ cursor is here 
) {}
```