### PR TITLE
Indenting "if" and "for" loops fixes

### DIFF
--- a/tsi-typescript.el
+++ b/tsi-typescript.el
@@ -153,9 +153,15 @@
            ((eq
              parent-type
              'if_statement)
-            (if (eq
-                 current-type
-                 'expression_statement)
+            (if (or (eq current-type 'expression_statement)
+                    (eq current-type 'return_statement))
+                tsi-typescript-indent-offset
+              nil))
+
+           ((or (eq parent-type 'for_statement)
+                (eq parent-type 'for_in_statement))
+            (if (or (eq current-type 'expression_statement)
+                    (eq current-type 'return_statement))
                 tsi-typescript-indent-offset
               nil))
 

--- a/tsi-typescript.test.el
+++ b/tsi-typescript.test.el
@@ -138,11 +138,20 @@ if (foo) {
 "
       :to-be-indented))
  
- (it "properly indents un-bracketed if statements"
+ (it "properly indents un-braced if statements"
      (expect
       "
 if (foo)
   bar();
+"
+      :to-be-indented))
+
+ (it "properly indents un-braced if statements when the body returns"
+     (expect
+      "
+if (foo)
+  return;
+frobnicate();
 "
       :to-be-indented))
 
@@ -543,6 +552,39 @@ type C = A &
 type X = {
   
 }
+"
+      :to-be-indented))
+
+ (it "properly indents for loop body in braces"
+     (expect
+      "
+for (let i = 0; i < 10; i++) {
+  i;
+}
+"
+      :to-be-indented))
+ (it "properly indents for loop single-statement body without braces"
+     (expect
+      "
+for (let i = 0; i < 10; i++)
+  i;
+frobnicate();
+"
+      :to-be-indented))
+ (it "properly indents for-of loop body in braces"
+     (expect
+      "
+for (const x of list) {
+  x;
+}
+"
+      :to-be-indented))
+ (it "properly indents for-of loop single-statement body without braces"
+     (expect
+      "
+for (const x of list)
+  x;
+frobnicate();
 "
       :to-be-indented))
 


### PR DESCRIPTION
* indent "if" and "for" loops without braces
* indent return statement after if